### PR TITLE
Fix: Requires numpy major version 1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # for nav cmzl
 boto3
-numpy
+numpy>=1.0.0,<2.0.0
 pandas
 
 # for 3d tile pointcloud


### PR DESCRIPTION
This fix restricts `numpy` to major version 1 (`>=1.0.0, <2.0.0`) in `requirements.txt`.

The CZML output code relies on `np.string_` and other deprecated features that were removed in `numpy` 2.0 and later.